### PR TITLE
Added !lunch and !lunchPlaces

### DIFF
--- a/sue/logic/poll.py
+++ b/sue/logic/poll.py
@@ -107,9 +107,9 @@ def lunch():
     """!lunch"""
 
     # retrieve the group-specific lunchPlaces
-    options = db.mFind('polls', 'group', msg.chatId).get('lunchPlaces', [])
+    options = db.mFind('polls', 'group', msg.chatId).get('lunchPlaces', None)
     # if lunchPlaces isn't in the database
-    if options == {}:
+    if options == None:
         return "There are no lunchPlaces set,\nset with !lunchPlaces <place1>, <place2>, ..."
     options =  ["Where should we get lunch?"] + options
     msg = Message._create_message(flask.request.form)

--- a/sue/logic/poll.py
+++ b/sue/logic/poll.py
@@ -107,7 +107,11 @@ def lunch():
     """!lunch"""
 
     # retrieve the group-specific lunchPlaces
-    options =  ["Where should we get lunch?"] + db.mFind('polls', 'group', msg.chatId).get('lunchPlaces', [])
+    options = db.mFind('polls', 'group', msg.chatId).get('lunchPlaces', [])
+    # if lunchPlaces isn't in the database
+    if options == {}:
+        return "There are no lunchPlaces set,\nset with !lunchPlaces <place1>, <place2>, ..."
+    options =  ["Where should we get lunch?"] + options
     msg = Message._create_message(flask.request.form)
 
     #


### PR DESCRIPTION
Not sure if there will be a route conflict since !lunch is a substring of !lunchPlaces. I put lunchPlaces first to try to minimize that possibility. I added the code to polls.py because it depends on !vote to let users vote, but there's no actual code dependencies. 

!lunchPlaces:
Instead of the poll "data" mongo-document it uses poll "lunchPlaces" to store a list of group-specific lunch locations. 

!lunch
This just uses lunchPlaces to generate a poll