### PR TITLE
reapply gpt context, add !name

### DIFF
--- a/apps/subaru/lib/subaru.ex
+++ b/apps/subaru/lib/subaru.ex
@@ -81,6 +81,14 @@ defmodule Subaru do
     |> result_id()
   end
 
+  def update_with(key, doc, collection) do
+    Query.new()
+    |> Query.update_with(key, doc, collection)
+    |> Query.return("NEW._id")
+    |> Query.exec()
+    |> result_id()
+  end
+
   # TODO: Currently I just use the Query API for these. I don't yet know what
   # their API or return type should look lke.
 

--- a/apps/subaru/lib/subaru/query.ex
+++ b/apps/subaru/lib/subaru/query.ex
@@ -1,5 +1,8 @@
 defmodule Subaru.Query do
   require Logger
+  import ExUnit.Assertions
+
+  @query_debug Application.compile_env(:sue, :query_debug, false)
 
   @moduledoc """
   The end goal is to have a stable wrapper for our DB that feels as good to use
@@ -15,7 +18,7 @@ defmodule Subaru.Query do
   @type t() :: %__MODULE__{
           q: queue(),
           bindvars: Map.t(),
-          statement: [String.t()],
+          statement: [bitstring()],
           context: [atom()],
           depth: integer(),
           writes: MapSet.t(),
@@ -87,24 +90,49 @@ defmodule Subaru.Query do
     push(q, item)
   end
 
-  @spec for(t, atom(), String.t()) :: t
+  @spec for(t, atom(), bitstring()) :: t
   def for(q, variableName, collection) do
     item = {:for, variableName, collection}
     push(q, item)
   end
 
-  @spec insert(t, any(), String.t()) :: t
+  @spec insert(t, any(), bitstring()) :: t
   def insert(q, doc, collection) do
     item = {:insert, doc, collection}
     push(q, item)
   end
 
-  @spec upsert(t, any(), any(), any(), String.t()) :: t
+  @spec upsert(t, any(), any(), any(), bitstring()) :: t
   def upsert(q, searchdoc, insertdoc, updatedoc, collection) do
     item = {:upsert, searchdoc, insertdoc, updatedoc, collection}
     push(q, item)
   end
 
+  @doc """
+  Updates a document in a specified collection with given key expression and new document data.
+
+  ## Parameters
+
+  - `q`: The Query struct, representing the current state of the query being built.
+  - `keyExpression`: The key of the document to update, either as "123456" or "myCollection/123456"
+  - `doc`: A map containing the document's new data.
+  - `collection`: The name of the collection containing the document.
+
+  ## Examples
+
+      Query.new()
+      |> Query.update_with("123456", %{field: "new value"}, "myCollection")
+      |> Query.exec()
+
+  This updates the document with key "123456" in "myCollection", setting its "field" to "new value".
+
+      Query.new()
+      |> Query.update_with("people/123456", %{field: "new value"}, "people")
+      |> Query.exec()
+
+  This also updates the document with key "123456" in "people", assuming "people/123456" is provided as a key expression.
+  """
+  @spec update_with(t, bitstring(), any(), bitstring()) :: t
   def update_with(q, keyExpression, doc, collection) do
     item = {:update_with, keyExpression, doc, collection}
     push(q, item)
@@ -175,8 +203,24 @@ defmodule Subaru.Query do
     push(q, item)
   end
 
+  @doc """
+  Retrieves a document from a specified collection by its ID.
+
+  ## Parameters
+
+  - `q`: The Query struct, representing the current state of the query being built.
+  - `collection`: The name of the collection from which to retrieve the document.
+  - `id`: The unique identifier of the document to retrieve. Can be provided with or without the collection name prefix.
+  """
   def get(q, collection, id) do
-    return(q, "DOCUMENT(\"#{collection}/#{id}\")")
+    cond do
+      String.contains?(id, "/") ->
+        assert Enum.at(String.split(id, "/"), 0) == collection
+        return(q, "DOCUMENT(#{quoted(id)})")
+
+      true ->
+        return(q, "DOCUMENT(\"#{collection}/#{id}\")")
+    end
   end
 
   def first(q, return \\ false) when is_boolean(return) do
@@ -192,7 +236,9 @@ defmodule Subaru.Query do
   @spec exec(t) :: DB.res()
   def exec(query) do
     {statement, bindvars, opts} = run(query)
-    Subaru.DB.exec(statement, bindvars, opts)
+    res = Subaru.DB.exec(statement, bindvars, opts)
+    if @query_debug, do: Logger.debug(res |> inspect())
+    res
   end
 
   @doc """
@@ -205,15 +251,17 @@ defmodule Subaru.Query do
     bindvars = q.bindvars
     opts = [write: MapSet.to_list(q.writes), read: MapSet.to_list(q.reads)]
 
-    # For debug purposes
-    maxlinelen =
-      statement
-      |> String.split("\n")
-      |> Enum.map(&String.length/1)
-      |> Enum.max()
+    if @query_debug do
+      # For debug purposes
+      maxlinelen =
+        statement
+        |> String.split("\n")
+        |> Enum.map(&String.length/1)
+        |> Enum.max()
 
-    # logborder = String.duplicate("*", maxlinelen)
-    # Logger.debug("EXECUTING QUERY:\n#{logborder}\n#{statement}\n#{logborder}")
+      logborder = String.duplicate("*", maxlinelen)
+      Logger.debug("EXECUTING QUERY:\n#{logborder}\n#{statement}\n#{logborder}")
+    end
 
     {statement, bindvars, opts}
   end
@@ -283,17 +331,37 @@ defmodule Subaru.Query do
     |> gen()
   end
 
-  defp gen({:update_with, keyExpression, doc, collection}, query) do
+  defp gen({:update_with, keyExpression, doc, collection}, query)
+       when is_bitstring(keyExpression) do
     bv_doc = generate_bindvar(doc)
     bv_coll = "@" <> generate_bindvar(collection)
 
-    statement = "UPDATE #{keyExpression} WITH #{bv_doc} IN #{bv_coll}"
+    # Directly handle the keyExpression format simplification
+    formatted_key_expr =
+      if keyExpression =~ ~r/^\d+$/ do
+        # If the keyExpression is purely numeric, quote it
+        quoted(keyExpression)
+      else
+        # Check if keyExpression is in "collection/numericKey" format and extract the numeric part
+        case Regex.run(~r/^[\w-]+\/(\d+)$/, keyExpression) do
+          [_, numeric_id] ->
+            # If so, use the numeric ID, quoted
+            quoted(numeric_id)
+
+          _ ->
+            # If not, use the keyExpression as is
+            keyExpression
+        end
+      end
+
+    statement = "UPDATE #{formatted_key_expr} WITH #{bv_doc} IN #{bv_coll}"
 
     query
     |> add_statement(statement)
     |> add_bindvar(bv_doc, doc)
     |> add_bindvar(bv_coll, collection)
     |> add_write_coll(collection)
+    |> add_read_coll(collection)
     |> gen()
   end
 
@@ -435,7 +503,7 @@ defmodule Subaru.Query do
     |> gen()
   end
 
-  @spec gen_statement(t) :: String.t()
+  @spec gen_statement(t) :: bitstring()
   defp gen_statement(query) do
     helper_gen_statement(query, query.statement, "")
   end

--- a/apps/subaru/test/subaru_test.exs
+++ b/apps/subaru/test/subaru_test.exs
@@ -90,4 +90,18 @@ defmodule SubaruTest do
     assert Subaru.exists?("chats", expr2) == false
     {:ok, _} = Subaru.DB.remove_collection("chats")
   end
+
+  test "update field" do
+    {:ok, _} = Subaru.DB.create_collection("people", :doc)
+
+    {:ok, jimmy_key} = Subaru.insert(%{name: "Jimmy", age: 100}, "people")
+    %{"name" => "Jimmy"} = Subaru.get!("people", jimmy_key)
+
+    {:ok, johnny_key} = Subaru.update_with(jimmy_key, %{name: "Johnny"}, "people")
+    %{"name" => "Johnny"} = Subaru.get!("people", johnny_key)
+
+    assert jimmy_key == johnny_key
+
+    {:ok, _} = Subaru.DB.remove_collection("people")
+  end
 end

--- a/apps/sue/lib/sue.ex
+++ b/apps/sue/lib/sue.ex
@@ -160,7 +160,7 @@ defmodule Sue do
   # Message/command from user
   defp log_and_cache_recent(msg, nil) do
     Sue.DB.RecentMessages.add(msg.chat.id, %{
-      name: msg.account.id,
+      name: Account.friendly_name(msg.account),
       body: msg.body,
       is_from_sue: false,
       is_from_gpt: false

--- a/apps/sue/lib/sue.ex
+++ b/apps/sue/lib/sue.ex
@@ -80,9 +80,9 @@ defmodule Sue do
   def debug_blocking_process_message(msg), do: execute_command(get_commands(), msg)
 
   @spec process_message(Message.t()) :: :ok
-  def process_message(%Message{is_ignorable: true}), do: :ok
+  defp process_message(%Message{is_ignorable: true}), do: :ok
 
-  def process_message(msg) do
+  defp process_message(msg) do
     Logger.info("[Sue] Processing: #{inspect(msg)}")
     GenServer.cast(__MODULE__, {:process, msg})
   end
@@ -160,7 +160,7 @@ defmodule Sue do
   # Message/command from user
   defp log_and_cache_recent(msg, nil) do
     Sue.DB.RecentMessages.add(msg.chat.id, %{
-      account_id: msg.account.id,
+      name: msg.account.id,
       body: msg.body,
       is_from_sue: false,
       is_from_gpt: false
@@ -171,7 +171,7 @@ defmodule Sue do
   # TODO: Log enough info to be able to use the file.
   defp log_and_cache_recent(msg, %Attachment{}) do
     Sue.DB.RecentMessages.add(msg.chat.id, %{
-      account_id: "sue",
+      name: "sue",
       body: "<media>",
       is_from_sue: true,
       is_from_gpt: false
@@ -184,7 +184,7 @@ defmodule Sue do
   # Sue response, non-attachment.
   defp log_and_cache_recent(msg, rsp) do
     Sue.DB.RecentMessages.add(msg.chat.id, %{
-      account_id: "sue",
+      name: "sue",
       body: if(rsp.body != "", do: rsp.body, else: "<media>"),
       is_from_sue: true,
       is_from_gpt: rsp.is_from_gpt

--- a/apps/sue/lib/sue/ai/ai.ex
+++ b/apps/sue/lib/sue/ai/ai.ex
@@ -3,6 +3,8 @@ defmodule Sue.AI do
 
   require Logger
 
+  alias Sue.Models.{Chat, Account}
+
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
@@ -12,8 +14,9 @@ defmodule Sue.AI do
     {:ok, []}
   end
 
-  @spec chat_completion(bitstring(), :gpt35 | :gpt4) :: bitstring()
-  def chat_completion(text, modelversion) when is_atom(modelversion) do
+  @spec chat_completion(bitstring(), :gpt35 | :gpt4, Chat.t(), Account.t()) :: bitstring()
+  def chat_completion(text, modelversion, chat, account)
+      when is_atom(modelversion) do
     model =
       case modelversion do
         :gpt35 -> "gpt-3.5-turbo"
@@ -22,14 +25,41 @@ defmodule Sue.AI do
 
     Logger.debug("Running chat_completion with #{model}")
 
+    maxlen = if account.is_premium, do: 4_000, else: 1_000
+
+    system_content_suffix =
+      if chat.is_direct do
+        " one other user."
+      else
+        " 2+ other users."
+      end
+
+    messages =
+      [
+        %{
+          role: "system",
+          content:
+            "You are a helpful assistant in a group chat with a chatbot named Sue and" <>
+              system_content_suffix
+        }
+      ] ++
+        recent_messages_for_context(chat.id, chat.is_direct, text, maxlen) ++
+        [
+          %{
+            role: "user",
+            content: "#{Account.friendly_name(account) |> format_user_id()} said " <> text
+          }
+        ]
+
+    Logger.debug(messages |> inspect(pretty: true))
+
     with {:ok, response} <-
            OpenAI.chat_completion(
              model: model,
-             messages: [
-               %{role: "user", content: text}
-             ]
+             messages: messages
            ) do
       [%{"message" => %{"content" => content}}] = response.choices
+      Logger.debug("GPT response: " <> content)
       content |> String.trim("\n")
     else
       {:error, :timeout} ->
@@ -43,6 +73,57 @@ defmodule Sue.AI do
         Logger.error("[Sue.AI.chat_completion()] #{status_message}")
         status_message
     end
+  end
+
+  defp remove_sue_prefix(str) do
+    Regex.replace(~r/^\((as )?sue\)\s*/i, str, "")
+  end
+
+  @spec recent_messages_for_context(Subaru.dbid(), boolean(), bitstring(), integer()) :: [map()]
+  defp recent_messages_for_context(chat_id, _is_direct, text, maxlen) do
+    Sue.DB.RecentMessages.get_tail(chat_id)
+    |> reduce_recent_messages(String.length(text), maxlen)
+    |> Enum.map(fn %{is_from_gpt: is_from_gpt, is_from_sue: is_from_sue} = m ->
+      role = if is_from_gpt, do: "assistant", else: "user"
+
+      content_prefix =
+        cond do
+          is_from_gpt ->
+            ""
+
+          is_from_sue ->
+            # "(as Sue) "
+            "SueBot said "
+
+          true ->
+            format_user_id(m.name) <> " said "
+        end
+
+      %{role: role, content: content_prefix <> m.body}
+    end)
+  end
+
+  defp format_user_id("sue_users/" <> user_id) do
+    "User" <> user_id
+  end
+
+  defp format_user_id(otherwise), do: otherwise
+
+  @spec reduce_recent_messages([map()], integer(), integer()) :: {integer(), [map()]}
+  defp reduce_recent_messages(recent_messages, promptlen, maxlen) do
+    {_chars_used, messages} =
+      Enum.reduce_while(recent_messages, {promptlen, []}, fn m, acc ->
+        {len, msgs} = acc
+        newlen = len + String.length(m.body)
+
+        if newlen <= maxlen do
+          {:cont, {newlen, msgs ++ [m]}}
+        else
+          {:halt, acc}
+        end
+      end)
+
+    messages
   end
 
   @doc """

--- a/apps/sue/lib/sue/commands/core.ex
+++ b/apps/sue/lib/sue/commands/core.ex
@@ -2,7 +2,7 @@ defmodule Sue.Commands.Core do
   Module.register_attribute(__MODULE__, :is_persisted, persist: true)
   @is_persisted "is persisted"
 
-  alias Sue.Models.{Message, Response, Account}
+  alias Sue.Models.{Message, Response, Account, Chat}
   require Logger
 
   @doc """
@@ -20,6 +20,17 @@ defmodule Sue.Commands.Core do
   def c_h_sleep(_m) do
     Process.sleep(5000)
     %Response{body: "zzz"}
+  end
+
+  def c_h_recentmessages(%Message{chat: %Chat{id: chat_id}}) do
+    recent_messages =
+      Sue.DB.RecentMessages.get(chat_id)
+      |> Enum.map(fn m -> "- " <> String.slice(m.body, 0, 20) end)
+      |> Enum.join("\n")
+
+    %Response{
+      body: if(recent_messages == "", do: "empty", else: recent_messages)
+    }
   end
 
   def c_h_ratetest(%Message{account: %Account{id: account_id}}) do

--- a/apps/sue/lib/sue/commands/core.ex
+++ b/apps/sue/lib/sue/commands/core.ex
@@ -13,6 +13,28 @@ defmodule Sue.Commands.Core do
     %Response{body: "pong!"}
   end
 
+  @doc """
+  Set a name for your account. Helpful when interacting with GPT.
+  Usage: !name Jimmy
+  """
+  def c_name(%Message{args: ""}) do
+    %Response{
+      body:
+        "Hmm, it seems like you didn't specify a name. To set your name, use !name followed by the name you'd like to use. See !help name for more information."
+    }
+  end
+
+  def c_name(%Message{args: name}) when byte_size(name) > 32 do
+    %Response{
+      body:
+        "The name you've chosen is a bit too long. Please keep it under 32 characters. Try again with a shorter name!"
+    }
+  end
+
+  def c_name(%Message{args: name}) do
+    %Response{body: "Name set to #{name}"}
+  end
+
   def c_h_debug(m) do
     %Response{body: m |> inspect()}
   end

--- a/apps/sue/lib/sue/commands/core.ex
+++ b/apps/sue/lib/sue/commands/core.ex
@@ -31,7 +31,8 @@ defmodule Sue.Commands.Core do
     }
   end
 
-  def c_name(%Message{args: name}) do
+  def c_name(%Message{args: name, account: %Account{id: account_id}}) do
+    :ok = Sue.DB.change_name(account_id, name)
     %Response{body: "Name set to #{name}"}
   end
 

--- a/apps/sue/lib/sue/commands/gpt.ex
+++ b/apps/sue/lib/sue/commands/gpt.ex
@@ -12,10 +12,13 @@ defmodule Sue.Commands.Gpt do
     %Response{body: "Please provide a request to ChatGPT. See !help gpt"}
   end
 
-  def c_gpt(%Message{args: args, account: %Account{id: account_id, is_premium: is_premium}}) do
+  def c_gpt(%Message{args: args, chat: chat, account: account}) do
     # Check rate limit for using gpt command: 50/day
-    with :ok <- Sue.Limits.check_rate("gpt:#{account_id}", @gpt_rate_limit, is_premium) do
-      %Response{body: Sue.AI.chat_completion(args, :gpt35), is_from_gpt: true}
+    with :ok <- Sue.Limits.check_rate("gpt:#{account.id}", @gpt_rate_limit, account.is_premium) do
+      %Response{
+        body: Sue.AI.chat_completion(args, :gpt35, chat, account),
+        is_from_gpt: true
+      }
     else
       :deny -> %Response{body: "Please slow down your requests. Try again in 24 hours."}
     end
@@ -32,8 +35,8 @@ defmodule Sue.Commands.Gpt do
     }
   end
 
-  def c_gpt4(%Message{account: %Account{is_premium: true}, args: args}) do
-    %Response{body: Sue.AI.chat_completion(args, :gpt4), is_from_gpt: true}
+  def c_gpt4(%Message{args: args, chat: chat, account: %Account{is_premium: true} = account}) do
+    %Response{body: Sue.AI.chat_completion(args, :gpt4, chat, account), is_from_gpt: true}
   end
 
   @doc """

--- a/apps/sue/lib/sue/commands/images.ex
+++ b/apps/sue/lib/sue/commands/images.ex
@@ -78,7 +78,7 @@ defmodule Sue.Commands.Images do
     %Attachment{filename: outpath}
   end
 
-  @spec random_image_from_dir(String.t()) :: Attachment.t()
+  @spec random_image_from_dir(bitstring()) :: Attachment.t()
   defp random_image_from_dir(dir) do
     path = Path.join(@media_path, dir)
 

--- a/apps/sue/lib/sue/commands/shell.ex
+++ b/apps/sue/lib/sue/commands/shell.ex
@@ -19,7 +19,7 @@ defmodule Sue.Commands.Shell do
     %Response{body: output_single_cmd("fortune")}
   end
 
-  @spec output_single_cmd(String.t()) :: String.t()
+  @spec output_single_cmd(bitstring()) :: bitstring()
   defp output_single_cmd(cmd) do
     {output, 0} = System.cmd(cmd, [])
     output

--- a/apps/sue/lib/sue/db/d_b.ex
+++ b/apps/sue/lib/sue/db/d_b.ex
@@ -232,4 +232,13 @@ defmodule Sue.DB do
 
     {:ok, Poll.from_doc(newpoll)}
   end
+
+  # ==========
+  # || User ||
+  # ==========
+  @spec change_name(Subaru.dbid(), bitstring()) :: :ok
+  def change_name(account_id, newname) do
+    {:ok, ^account_id} = Subaru.update_with(account_id, %{name: newname}, Account.collection())
+    :ok
+  end
 end

--- a/apps/sue/lib/sue/db/recent_messages.ex
+++ b/apps/sue/lib/sue/db/recent_messages.ex
@@ -21,8 +21,8 @@ defmodule Sue.DB.RecentMessages do
 
   @type queue() :: Queue.queue()
 
-  # Keep 5 prev messages per chat
-  @context_length 5
+  # Keep 6 prev messages per chat
+  @context_length 6
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
@@ -71,5 +71,18 @@ defmodule Sue.DB.RecentMessages do
   @spec get(Subaru.dbid()) :: [map()]
   def get(chat_id) when is_dbid(chat_id) do
     GenServer.call(__MODULE__, {:get, chat_id})
+  end
+
+  @doc """
+  Get recent messages, ignoring the most recent. Useful when a command was just
+  executed (and thus logged) and we only care about the msgs just before then.
+  """
+  @spec get_tail(Subaru.dbid()) :: [map()]
+  def get_tail(chat_id) when is_dbid(chat_id) do
+    # Somehow this is fastest https://stackoverflow.com/a/52322926/2877738
+    get(chat_id)
+    |> Enum.reverse()
+    |> tl()
+    |> Enum.reverse()
   end
 end

--- a/apps/sue/lib/sue/mailbox/telegram.ex
+++ b/apps/sue/lib/sue/mailbox/telegram.ex
@@ -34,8 +34,13 @@ defmodule Sue.Mailbox.Telegram do
     context
   end
 
-  def handle({:text, _text, _msg}, _context) do
+  def handle({:text, _text, msg}, context) do
     # Direct text or reply in group
+    Logger.debug("=== begin :text handle ===")
+    item = %{msg: msg, context: context}
+    Logger.debug(item |> inspect())
+    Sue.process_messages([Message.from_telegram(item)])
+    Logger.debug("=== end :text handle ===")
     :ok
   end
 

--- a/apps/sue/lib/sue/models/account.ex
+++ b/apps/sue/lib/sue/models/account.ex
@@ -53,6 +53,14 @@ defmodule Sue.Models.Account do
     }
   end
 
+  def friendly_name(a) do
+    case {a.name, a.handle, a.id} do
+      {"", "", id} -> id
+      {"", handle, _} -> handle
+      {name, _handle, _} -> name
+    end
+  end
+
   @impl Subaru.Vertex
   def collection(), do: @collection
 

--- a/apps/sue/lib/sue/models/account.ex
+++ b/apps/sue/lib/sue/models/account.ex
@@ -55,7 +55,7 @@ defmodule Sue.Models.Account do
 
   def friendly_name(a) do
     case {a.name, a.handle, a.id} do
-      {"", "", id} -> id
+      {"", "", id} -> "User" <> Sue.Utils.dbid_number(id)
       {"", handle, _} -> handle
       {name, _handle, _} -> name
     end

--- a/apps/sue/lib/sue/models/defn.ex
+++ b/apps/sue/lib/sue/models/defn.ex
@@ -5,8 +5,8 @@ defmodule Sue.Models.Defn do
   defstruct [:var, :val, :type, :date_created, :date_modified, :id]
 
   @type t() :: %__MODULE__{
-          var: String.t(),
-          val: String.t() | integer(),
+          var: bitstring(),
+          val: bitstring() | integer(),
           type: :text | :num | :bin | :func,
           date_created: integer(),
           date_modified: integer(),

--- a/apps/sue/lib/sue/models/message.ex
+++ b/apps/sue/lib/sue/models/message.ex
@@ -50,9 +50,9 @@ defmodule Sue.Models.Message do
           chat: Chat.t(),
           account: Account.t() | nil,
           ###
-          body: String.t(),
-          command: String.t(),
-          args: String.t(),
+          body: bitstring(),
+          command: bitstring(),
+          args: bitstring(),
           attachments: [Attachment.t()] | nil,
           time: DateTime.t(),
           ###
@@ -295,8 +295,8 @@ defmodule Sue.Models.Message do
   # TODO: Replace all of this with regular expressions.
 
   # returns {command, args, body}
-  @spec command_args_from_body(Platform.t(), String.t()) ::
-          {String.t(), String.t(), String.t()}
+  @spec command_args_from_body(Platform.t(), bitstring()) ::
+          {bitstring(), bitstring(), bitstring()}
   defp command_args_from_body(platform, body) do
     if has_command?(platform, body) do
       trimmed_body = body |> better_trim()

--- a/apps/sue/lib/sue/models/message.ex
+++ b/apps/sue/lib/sue/models/message.ex
@@ -117,8 +117,11 @@ defmodule Sue.Models.Message do
   def from_telegram(%{msg: msg, context: context} = update) do
     {command, args, body} =
       case Map.get(update, :command) do
-        nil -> command_args_from_body(:telegram, Map.get(msg, :caption, ""))
-        c -> {c, msg.text, context.update.message.text}
+        nil ->
+          command_args_from_body(:telegram, Map.get(msg, :caption, Map.get(msg, :text, "")))
+
+        c ->
+          {c, msg.text, context.update.message.text}
       end
 
     command =
@@ -148,7 +151,7 @@ defmodule Sue.Models.Message do
       chat: chat,
       account: account,
       #
-      body: body |> better_trim(),
+      body: body,
       time: DateTime.from_unix!(msg.date),
       #
       is_from_sue: false,

--- a/apps/sue/lib/sue/models/poll.ex
+++ b/apps/sue/lib/sue/models/poll.ex
@@ -7,8 +7,8 @@ defmodule Sue.Models.Poll do
   @type interface() :: :standard | :platform
   @type t() :: %__MODULE__{
           chat_id: Subaru.dbid(),
-          topic: String.t(),
-          options: [String.t()],
+          topic: bitstring(),
+          options: [bitstring()],
           # k:AccountID, v:ChoiceIndex
           votes: map(),
           interface: interface(),

--- a/apps/sue/lib/utils.ex
+++ b/apps/sue/lib/utils.ex
@@ -1,4 +1,8 @@
 defmodule Sue.Utils do
+  def dbid_number(dbid) do
+    Enum.at(String.split(dbid, "/"), 1)
+  end
+
   def quoted(s) when is_bitstring(s) do
     "\"#{s}\""
   end

--- a/apps/sue/lib/utils.ex
+++ b/apps/sue/lib/utils.ex
@@ -3,7 +3,7 @@ defmodule Sue.Utils do
     "\"#{s}\""
   end
 
-  @spec tokenize(String.t()) :: [String.t()]
+  @spec tokenize(bitstring()) :: [bitstring()]
   def tokenize(args) do
     cond do
       String.contains?(args, "\n") -> String.split(args, "\n")

--- a/config/config.exs
+++ b/config/config.exs
@@ -87,7 +87,8 @@ config :hammer,
 
 config :sue,
   # options include :discord, :imessage, :telegram - :debug is just for testing
-  platforms: [:debug, :discord, :imessage, :telegram],
+  # platforms: [:debug, :discord, :imessage, :telegram],
+  platforms: [:debug, :telegram],
   chat_db_path: Path.join(System.user_home(), "Library/Messages/chat.db"),
   # Rate limits
   cmd_rate_limit: {:timer.seconds(5), 5},

--- a/config/config.exs
+++ b/config/config.exs
@@ -87,8 +87,7 @@ config :hammer,
 
 config :sue,
   # options include :discord, :imessage, :telegram - :debug is just for testing
-  # platforms: [:debug, :discord, :imessage, :telegram],
-  platforms: [:debug, :telegram],
+  platforms: [:debug, :discord, :imessage, :telegram],
   chat_db_path: Path.join(System.user_home(), "Library/Messages/chat.db"),
   # Rate limits
   cmd_rate_limit: {:timer.seconds(5), 5},

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,4 +11,5 @@ config :desu_web, DesuWeb.Endpoint,
 config :logger, level: :debug
 
 config :sue,
-  cmd_rate_limit: {:timer.seconds(5), 5000}
+  cmd_rate_limit: {:timer.seconds(5), 5000},
+  query_debug: false


### PR DESCRIPTION
Back when we added support to pass the last few chat messages to GPT for added context - it would occasionally call users by their sue_users ID, which freaked them out. Add a new !name command to let them change their name, which makes the interaction a bit more personable.