### PR TITLE
restore log_and_cache_recent(%Attachment{}) clause

### DIFF
--- a/apps/sue/lib/sue.ex
+++ b/apps/sue/lib/sue.ex
@@ -161,7 +161,7 @@ defmodule Sue do
   end
 
   # Message from Sue
-  @spec log_and_cache_recent(Message.t(), Response.t() | nil) :: :ok
+  @spec log_and_cache_recent(Message.t(), Response.t() | Attachment.t() | nil) :: :ok
   defp log_and_cache_recent(%Message{is_from_sue: true}, nil), do: :ok
 
   # Message/command from user
@@ -170,6 +170,17 @@ defmodule Sue do
       name: Account.friendly_name(msg.account),
       body: msg.body,
       is_from_sue: false,
+      is_from_gpt: false
+    })
+  end
+
+  # Sue response, attachment.
+  # TODO: Log enough info to be able to use the file.
+  defp log_and_cache_recent(msg, %Attachment{}) do
+    Sue.DB.RecentMessages.add(msg.chat.id, %{
+      name: "sue",
+      body: "<media>",
+      is_from_sue: true,
       is_from_gpt: false
     })
   end

--- a/apps/sue/lib/sue.ex
+++ b/apps/sue/lib/sue.ex
@@ -136,7 +136,7 @@ defmodule Sue do
     :ok
   end
 
-  @spec execute_command(map(), Message.t()) :: Response.t()
+  @spec execute_command(map(), Message.t()) :: Response.t() | Attachment.t() | [Attachment.t()]
   defp execute_command(_, %Message{account: %Account{is_banned: true, ban_reason: ban_reason}}) do
     %Response{
       body: "User is banned for reason: '#{ban_reason}'. May God have mercy on your soul."


### PR DESCRIPTION
## Summary
- Restores the `log_and_cache_recent(%Attachment{})` pattern-match clause that was removed in 68d3f5a as "dead code."
- Image commands (`!doog`, `!1984`, `!cringe`, `!qt`) return a bare `%Attachment{}` rather than a `%Response{}`. Without the clause they fall through to the `%Response{}` branch and crash with `KeyError` on `rsp.body`, killing the task before `send_response` ever runs — which is why image commands silently stopped working in iMessage.
- `@spec` updated to re-include `Attachment.t()`. Body of the restored clause is verbatim from the pre-68d3f5a version.

Example crash from `~/Library/Logs/sue/error.log`:
```
** (KeyError) key :body not found in: %Sue.Models.Attachment{
  filepath: ".../priv/media/korone.JPG", downloaded: true, ...}
    (sue 0.2.3) lib/sue.ex:184: Sue.log_and_cache_recent/2
```

## Test plan
- [ ] `mix compile` clean
- [ ] `mix dialyzer` still exits 0 (spec now matches call sites)
- [ ] Rebuild prod release, restart, confirm `!doog` / `!cringe` / `!qt` / `!1984` send images over iMessage
- [ ] Confirm no new `KeyError` entries in `~/Library/Logs/sue/error.log` after sending an image command
